### PR TITLE
Added shim for deprecated function

### DIFF
--- a/chrome-extension-async.d.ts
+++ b/chrome-extension-async.d.ts
@@ -6296,7 +6296,7 @@ declare namespace chrome.tabs {
      */
     export function executeScript(tabId: number, details: InjectDetails, callback?: (result: any[]) => void): Promise<any[]>;
     /** Retrieves details about the specified tab. */
-    export function get(tabId: number, callback: (tab: Tab) => void): Promise<Tab>;
+    export function get(tabId: number, callback?: (tab: Tab) => void): Promise<Tab>;
     /**
      * Gets details about all tabs in the specified window.
      * @deprecated since Chrome 33. Please use tabs.query {windowId: windowId}.

--- a/chrome-extension-async.d.ts
+++ b/chrome-extension-async.d.ts
@@ -4968,7 +4968,7 @@ declare namespace chrome.runtime {
      * @since Chrome 26.
      */
     interface Port {
-        postMessage: (message: Object) => void;
+        postMessage: (message: any) => void;
         disconnect: () => void;
         /**
          * Optional.
@@ -4994,7 +4994,7 @@ declare namespace chrome.runtime {
 
     interface PortDisconnectEvent extends chrome.events.Event<(port: Port) => void> { }
 
-    interface PortMessageEvent extends chrome.events.Event<(message: Object, port: Port) => void> { }
+    interface PortMessageEvent extends chrome.events.Event<(message: any, port: Port) => void> { }
 
     interface ExtensionMessageEvent extends chrome.events.Event<(message: any, sender: MessageSender, sendResponse: (response: any) => void) => void> { }
 

--- a/chrome-extension-async.js
+++ b/chrome-extension-async.js
@@ -227,7 +227,7 @@
             { n: 'storage', props: ['getInfo', 'ejectDevice', 'getAvailableCapacity'] }],
         tabCapture: ['capture', 'getCapturedTabs'],
         tabs: [
-            'get', 'getAllInWindow', 'getCurrent', 'sendMessage', 'create', 'duplicate',
+            'get', 'getCurrent', 'sendMessage', 'create', 'duplicate',
             'query', 'highlight', 'update', 'move', 'reload', 'remove',
             'detectLanguage', 'captureVisibleTab', 'executeScript',
             'insertCSS', 'setZoom', 'getZoom', 'setZoomSettings',
@@ -240,4 +240,10 @@
         webNavigation: ['getFrame', 'getAllFrames', 'handlerBehaviorChanged'],
         windows: ['get', 'getCurrent', 'getLastFocused', 'getAll', 'create', 'update', 'remove']
     });
+    
+    /** Gets details about all tabs in the specified window.
+     * @param {number} windowId Defaults to the current window.
+     * @returns {Promise} Resolves to an array of tabs in the specified window */
+    chrome.tabs.getAllInWindow = windowId =>
+        chrome.tabs.query({windowId: windowId});
 })();


### PR DESCRIPTION
Rather than adding the [deprecated](https://developer.chrome.com/extensions/tabs#method-getAllInWindow) function `tabs.getAllInWindow` why not replace it with a call to the recommended replacement?